### PR TITLE
Fix wrong code coverage report

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,12 @@
 image: Visual Studio 2017
 
 install: 
-  - ps: |
-        dotnet --version
-        $PSVersionTable
-        Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+  - ps: Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
 
 build_script:
-  - ps: $PSVersionTable # needed because otherwise AppVeyor complains
+  - ps: | 
+        $PSVersionTable
+        dotnet --version
 
 test_script:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
         Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
 
 build_script:
-  - ps: Import-Module .\posh-dotnet.psd1 # needed because otherwise AppVeyor complains
+  - ps: $PSVersionTable # needed because otherwise AppVeyor complains
 
 test_script:
   - ps: |

--- a/posh-dotnet.psd1
+++ b/posh-dotnet.psd1
@@ -12,7 +12,7 @@
 RootModule = 'posh-dotnet.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.1'
+ModuleVersion = '1.0.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/posh-dotnet.psm1
+++ b/posh-dotnet.psm1
@@ -18,7 +18,7 @@ if ($global:DotnetCompletion.Count -eq 0)
         elseif ($_ -match $flagRegex)
         {
             $global:DotnetCompletion["options"] += $Matches[1]
-            if ($Matches[2] -ne $null)
+            if ($null -ne $Matches[2])
             {
                 $global:DotnetCompletion["options"] += $Matches[2]
             }

--- a/posh-dotnet.tests.ps1
+++ b/posh-dotnet.tests.ps1
@@ -4,10 +4,8 @@
 Describe 'TabExpansion2' {
     
     $poshdotnet_moduleName = 'posh-dotnet'
-    if ($null -ne (Get-Module $poshdotnet_moduleName -ListAvailable)) {
-        Remove-Module $poshdotnet_moduleName
-    }
-    Import-Module (Join-Path $PSScriptRoot "$poshdotnet_moduleName.psd1")
+    # Note that the module does not get re-imported because removing the module would also remove the TabExpansion2 function
+    Import-Module (Join-Path $PSScriptRoot "$poshdotnet_moduleName.psd1") 
     
     It "dotnet b gets expanded to dotnet build" {
         $commandCompletion = TabExpansion2 -inputScript "dotnet b" -cursorColumn 8


### PR DESCRIPTION
problem was that module already got imported before pester test in ci
also bumps the patch version and fixes a swallowed pssa warning